### PR TITLE
Fix url_from_remote

### DIFF
--- a/bin/common/origin
+++ b/bin/common/origin
@@ -7,7 +7,7 @@ fi
 
 # $1 remote
 function url_from_remote {
-    echo $1 | sed -Ene 's/^.*[:\/]([-a-zA-Z1-9]*)\/([-a-zA-Z1-9\._]*)$/\1\/\2/pg'
+    echo $1 | sed -Ene 's/^.*[:\/]([-a-zA-Z0-9]*)\/([-a-zA-Z0-9\._]*)$/\1\/\2/pg'
 }
 
 ORIGIN=$(url_from_remote $ORIGIN_URL)


### PR DESCRIPTION

url_from_remote would fail if the username or repo had `0` in it.
I have checked other locations which did 0-9 already
#### Changes
Fixes regex for url_from_remote