### PR TITLE
Non-interactive `cpr`

### DIFF
--- a/bin/cpr
+++ b/bin/cpr
@@ -82,11 +82,21 @@ EOF
 " > $FORM
 fi
 
-if [ -z "$EDITOR" ]
+if [ -t 0 ]
 then
-    nano $FORM
+    if [ -z "$EDITOR" ]
+    then
+        nano $FORM
+    else
+        $EDITOR $FORM
+    fi
 else
-    $EDITOR $FORM
+    echo "Write your PR description to: $FORM"
+    echo "Press Enter when ready to submit."
+    # If stdin is a pipe, wait for a signal (newline) before submitting.
+    # This lets a non-interactive caller write the form then unblock us.
+    # If stdin is /dev/null or a file, read returns immediately (EOF).
+    read -r _
 fi
 
 if [ ! -s $FORM ]


### PR DESCRIPTION
#### Changes
When `cpr` runs without a TTY (e.g. from an AI agent or script), it now:
- Prints the form path so the caller knows where to write the PR description
- Blocks on `read` so a piped caller can write the form before submission
- Returns immediately on EOF, so pre-writing the form and running with `stdin < /dev/null` also works

Reviewers @wjmelements